### PR TITLE
chore - add cypress dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /home/circleci
 RUN sudo apt-get install less
 
 # Install cypress dependencies
-RUN sudo apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+RUN sudo apt-get install libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6
 
 # Install AWS CLI and set TERM variable
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ WORKDIR /home/circleci
 
 RUN sudo apt-get install less
 
+# Install cypress dependencies
+RUN sudo apt-get install libgtk2.0-0 libgtk-3-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
 # Install AWS CLI and set TERM variable
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
   unzip awscliv2.zip && \


### PR DESCRIPTION
- adds cypress dependencies https://docs.cypress.io/guides/guides/continuous-integration.html#Dependencies
- added it as an extra line after the less command because it feels nicer to keep them separate but not fussed
- ~not 100% sure if any of these might already be in the base image: if anyone has a good way to check, let me know~ obviously it tells you if something is already installed/at the latest version - removed these